### PR TITLE
Implement depth image resize

### DIFF
--- a/dlimp/transforms/frame_transforms.py
+++ b/dlimp/transforms/frame_transforms.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Sequence, Tuple, Union
 import tensorflow as tf
 
 from dlimp.augmentations import augment_image
-from dlimp.utils import resize_image
+from dlimp.utils import resize_image, resize_depth_image
 
 from .common import selective_tree_map
 
@@ -40,6 +40,25 @@ def resize_images(
         lambda keypath, value: any([s in keypath for s in match])
         and value.dtype == tf.uint8,
         partial(resize_image, size=size),
+    )
+
+
+def resize_depth_images(
+    x: Dict[str, Any],
+    match: Union[str, Sequence[str]] = "depth",
+    size: Tuple[int, int] = (128, 128),
+) -> Dict[str, Any]:
+    """Can operate on nested dicts. Resizes any leaves that have `match` anywhere in their path. Takes float32 images
+    as input and returns float images (in arbitrary range).
+    """
+    if isinstance(match, str):
+        match = [match]
+
+    return selective_tree_map(
+        x,
+        lambda keypath, value: any([s in keypath for s in match])
+        and value.dtype == tf.float32,
+        partial(resize_depth_image, size=size),
     )
 
 

--- a/dlimp/utils.py
+++ b/dlimp/utils.py
@@ -16,6 +16,16 @@ def resize_image(image: tf.Tensor, size: Tuple[int, int]) -> tf.Tensor:
     return image
 
 
+def resize_depth_image(depth_image: tf.Tensor, size: Tuple[int, int]) -> tf.Tensor:
+    """Resizes a depth image using bilinear interpolation. Expects & returns float32 in arbitrary range."""
+    assert depth_image.dtype == tf.float32
+    if len(depth_image.shape) < 3:
+        depth_image = tf.image.resize(depth_image[..., None], size, method="bilinear", antialias=True)[..., 0]
+    else:
+        depth_image = tf.image.resize(depth_image, size, method="bilinear", antialias=True)
+    return depth_image
+
+
 def read_resize_encode_image(path: str, size: Tuple[int, int]) -> tf.Tensor:
     """Reads, decodes, resizes, and then re-encodes an image."""
     data = tf.io.read_file(path)


### PR DESCRIPTION
Implements resizing for depth images.
I verified that tf keeps the original range for tf.float32 resizes.
Here are examples where I also compare bilinear vs nearest neighbor resize: https://colab.research.google.com/drive/1LyyCrUBRu0PHTkWUCqSYJCpuHRLMF1xv?usp=sharing